### PR TITLE
[FEAT/#28] 게시글 생성 API

### DIFF
--- a/src/main/java/edu/aivle/heatguard_ai_back/controller/NoticeController.java
+++ b/src/main/java/edu/aivle/heatguard_ai_back/controller/NoticeController.java
@@ -2,10 +2,14 @@ package edu.aivle.heatguard_ai_back.controller;
 
 
 import edu.aivle.heatguard_ai_back.dto.ApiResponse;
+import edu.aivle.heatguard_ai_back.dto.notice.request.NoticeCreateRequest;
+import edu.aivle.heatguard_ai_back.dto.notice.response.NoticeCreateResponse;
 import edu.aivle.heatguard_ai_back.dto.notice.response.NoticeDetailResponse;
 import edu.aivle.heatguard_ai_back.service.NoticeService;
 import edu.aivle.heatguard_ai_back.dto.notice.response.NoticeListResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -40,10 +44,19 @@ public class NoticeController {
         return notice_file_cd + "notice file download ok";
     }
 
-    // 게시판 작성
+    // 게시판 생성(작성)
     @PostMapping("/create")
-    public String postNoticeCreate() {
-        return "notice create ok";
+    public ResponseEntity<ApiResponse<NoticeCreateResponse>> createNotice(
+            @Valid @RequestBody NoticeCreateRequest req
+    ) {
+        try {
+            NoticeCreateResponse res = noticeService.createNotice(req);
+            return ResponseEntity.ok(ApiResponse.success(res));
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure(e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure("공지 등록 중 오류가 발생했습니다."));
+        }
     }
 
     // 게시판 삭제

--- a/src/main/java/edu/aivle/heatguard_ai_back/dto/notice/request/NoticeCreateRequest.java
+++ b/src/main/java/edu/aivle/heatguard_ai_back/dto/notice/request/NoticeCreateRequest.java
@@ -1,0 +1,39 @@
+package edu.aivle.heatguard_ai_back.dto.notice.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class NoticeCreateRequest {
+
+    @JsonProperty("user_cd")
+    @NotBlank
+    private String userCd;
+
+    @JsonProperty("notice_title")
+    @NotBlank
+    private String noticeTitle;
+
+    @JsonProperty("cf_cd")
+    @NotBlank
+    private String cfCd;
+
+    @JsonProperty("notice_type")
+    @NotBlank
+    private String noticeType;
+
+    @JsonProperty("notice_content")
+    private String noticeContent;
+
+    @JsonProperty("notice_file_cd")
+    @NotNull
+    private Integer noticeFileCd;   // 필수 값 (첨부파일 업로드 api 리턴값)
+
+    @JsonProperty("notice_fix_yn")
+    @NotNull
+    private Boolean noticeFixYn;
+}

--- a/src/main/java/edu/aivle/heatguard_ai_back/dto/notice/response/NoticeCreateResponse.java
+++ b/src/main/java/edu/aivle/heatguard_ai_back/dto/notice/response/NoticeCreateResponse.java
@@ -1,0 +1,13 @@
+package edu.aivle.heatguard_ai_back.dto.notice.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NoticeCreateResponse {
+
+    @JsonProperty("notice_cd")
+    private Integer noticeCd;
+}

--- a/src/main/java/edu/aivle/heatguard_ai_back/repository/NoticeFileRepository.java
+++ b/src/main/java/edu/aivle/heatguard_ai_back/repository/NoticeFileRepository.java
@@ -3,5 +3,5 @@ package edu.aivle.heatguard_ai_back.repository;
 import edu.aivle.heatguard_ai_back.entity.NoticeFileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface NoticeFileRepository extends JpaRepository<NoticeFileEntity, Long> {
+public interface NoticeFileRepository extends JpaRepository<NoticeFileEntity, Integer> {
 }

--- a/src/main/java/edu/aivle/heatguard_ai_back/service/NoticeService.java
+++ b/src/main/java/edu/aivle/heatguard_ai_back/service/NoticeService.java
@@ -7,16 +7,20 @@
 
 package edu.aivle.heatguard_ai_back.service;
 
+import edu.aivle.heatguard_ai_back.dto.notice.request.NoticeCreateRequest;
+import edu.aivle.heatguard_ai_back.dto.notice.response.NoticeCreateResponse;
 import edu.aivle.heatguard_ai_back.dto.notice.response.NoticeDetailResponse;
 import edu.aivle.heatguard_ai_back.dto.notice.response.NoticeListResponse;
 import edu.aivle.heatguard_ai_back.entity.NoticeEntity;
 import edu.aivle.heatguard_ai_back.entity.NoticeFileEntity;
+import edu.aivle.heatguard_ai_back.repository.NoticeFileRepository;
 import edu.aivle.heatguard_ai_back.repository.NoticeRepository;
 import edu.aivle.heatguard_ai_back.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -24,6 +28,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NoticeService {
     private final NoticeRepository noticeRepository;
+    private final NoticeFileRepository noticeFileRepository;
     private final UserRepository userRepository;
 
     /**
@@ -119,6 +124,39 @@ public class NoticeService {
                 .noticeContent(notice.getNoticeContent())
                 .noticeFile(fileDto)
                 .build();
+    }
+    /**
+     * 3.[POST] 게시판 생성
+     */
+    @Transactional
+    public NoticeCreateResponse createNotice(NoticeCreateRequest req) {
+
+        // 1) 파일 존재 확인
+        NoticeFileEntity file = noticeFileRepository.findById(req.getNoticeFileCd())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 notice_file_cd 입니다."));
+
+        // 2) 이미 다른 공지에 연결된 파일이면 막기 (선택이지만 추천)
+        if (file.getNoticeCd() != null) {
+            throw new IllegalStateException("이미 공지에 연결된 첨부파일입니다.");
+        }
+
+        // 3) Notice 저장 (PK 생성)
+        NoticeEntity notice = new NoticeEntity();
+        notice.setUserCd(req.getUserCd());
+        notice.setCfCd(req.getCfCd());
+        notice.setNoticeTitle(req.getNoticeTitle());
+        notice.setNoticeType(req.getNoticeType());
+        notice.setNoticeContent(req.getNoticeContent());
+        notice.setNoticeFixYn(req.getNoticeFixYn());
+
+        NoticeEntity saved = noticeRepository.save(notice);
+        Integer noticeCd = saved.getNoticeCd();
+
+        // 4) NoticeFileEntity에 notice_cd 업데이트
+        file.setNoticeCd(noticeCd);
+        noticeFileRepository.save(file);
+
+        return new NoticeCreateResponse(noticeCd);
     }
 
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #28 

## Work Description ✏️
- 게시글 생성 API

## Screenshot 📸
<img width="360" height="1008" alt="image" src="https://github.com/user-attachments/assets/4819ec42-7f27-4999-84a2-695f5725eced" />

## To Reviewers 📢
본 API는 게시판 첨부파일 업로드 API(POST /api/notice/file/upload) 호출 후 사용해야 하는 API입니다.
[사용순서]
1. 게시판 첨부파일 업로드 API(POST /api/notice/file/upload) 
2. 게시글 등록 API(POST /api/notice/create)
-> 1의 리턴값인 notice_file_cd를 2의 파람 중 하나로 반드시 전달 
3. 게시글 등록 및 첨부파일 저장 완료